### PR TITLE
Fix long footnote URLs causing page overflow

### DIFF
--- a/sources/webapp/resources/js/components/Pages/Commentary.vue
+++ b/sources/webapp/resources/js/components/Pages/Commentary.vue
@@ -88,7 +88,7 @@
             {{ $t('footnotes') }}
         </h2>
         <ul>
-            <li v-for="(footnote, index) in store.footnotes" :key="index" class="mb-2 ml-12 list-decimal" v-html="footnote"></li>
+            <li v-for="(footnote, index) in store.footnotes" :key="index" class="mb-2 ml-12 list-decimal break-all" v-html="footnote"></li>
         </ul>
     </div>
 


### PR DESCRIPTION
Add's `break-all` to footnotes so that long URLs don't overflow the container and cause print/PDF issues.